### PR TITLE
Remove OpenMP dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 main: main.cpp full_bipartitegraph.h network_simplex_simple.h
-	g++ -std=c++11 -Ofast -march=native -fno-signed-zeros -fno-trapping-math -fopenmp -openmp -frename-registers -funroll-loops main.cpp -o transport
+	$(CXX) -std=c++11 -Ofast -march=native -fno-signed-zeros -fno-trapping-math -fopenmp -openmp -frename-registers -funroll-loops main.cpp -o transport
 #g++ -std=c++11 -Ofast -march=native -fno-signed-zeros -fno-trapping-math -fopenmp -frename-registers -funroll-loops -D_GLIBCXX_PARALLEL main.cpp

--- a/full_bipartitegraph.h
+++ b/full_bipartitegraph.h
@@ -1,12 +1,12 @@
 /* -*- mode: C++; indent-tabs-mode: nil; -*-
  *
- * This file has been adapted by Nicolas Bonneel (2013), 
+ * This file has been adapted by Nicolas Bonneel (2013),
  * from full_graph.h from LEMON, a generic C++ optimization library,
  * to implement a lightweight fully connected bipartite graph. A previous
- * version of this file is used as part of the Displacement Interpolation 
- * project, 
+ * version of this file is used as part of the Displacement Interpolation
+ * project,
  * Web: http://www.cs.ubc.ca/labs/imager/tr/2011/DisplacementInterpolation/
- * 
+ *
  *
  **** Original file Copyright Notice :
  * Copyright (C) 2003-2010
@@ -73,7 +73,7 @@ namespace lemon {
 
     int _node_num;
 	int64_t _arc_num;
-	
+
     FullBipartiteDigraphBase() {}
 
     void construct(int n1, int n2) { _node_num = n1+n2; _arc_num = (int64_t)n1 * (int64_t)n2; _n1=n1; _n2=n2;}

--- a/main.cpp
+++ b/main.cpp
@@ -10,11 +10,11 @@
 
 #include <iostream>
 #include <vector>
-
 #include "network_simplex_simple.h"
 #include <chrono>
 
 #include <stdio.h>
+
 
 
 using namespace lemon;


### PR DESCRIPTION
Hi!

I've found your project quite useful, and I wanted to offer the (largely cosmetic) tweaks I made that make it a bit more ergonomic.

1. I wrapped the OpenMP pragmas and include in `#ifdef _OPENMP`, so that code can build without warnings if OpenMP is disabled.
2. I replaced MAX with MAX_VAL. Some vendors use MAX as a macro, and this solved a compilation issue with me on OSX. I believe Windows may also.
3. I templated ProxyObject and SparseVector under the container so that the user can provide their own dictionary (as `std::unordered_map` is rather slow), and simplified the code using them with the keyword auto.

Thanks for your contribution!

